### PR TITLE
Fix DC on wg0 interface

### DIFF
--- a/imageroot/actions/configure-module/05set_env
+++ b/imageroot/actions/configure-module/05set_env
@@ -27,6 +27,7 @@ import os
 import secrets
 import string
 import cluster.userdomains
+import ipaddress
 
 module_id = os.environ['MODULE_ID']
 request = json.load(sys.stdin)
@@ -39,6 +40,7 @@ if 'REALM' in os.environ:
     sys.exit(1)
 
 with agent.redis_connect() as rdb:
+    cluster_network = ipaddress.ip_network(rdb.get('cluster/network'))
     domains = cluster.userdomains.get_internal_domains(rdb)
     kdomain = realm.lower()
 
@@ -64,6 +66,8 @@ agent.set_env('NBDOMAIN', nbdomain)
 agent.set_env('REALM', realm)
 agent.set_env('HOSTNAME', hostname + '.' + realm.lower())
 agent.set_env('IPADDRESS', request['ipaddress'])
+if ipaddress.ip_address(request['ipaddress']) in cluster_network:
+    agent.set_env('PREFIXLEN', str(cluster_network.prefixlen))
 agent.set_env('SVCUSER', 'ldapservice')
 agent.set_env('SVCPASS', svcpass)
 

--- a/imageroot/actions/configure-module/40start_provisioning
+++ b/imageroot/actions/configure-module/40start_provisioning
@@ -38,6 +38,7 @@ adminpass="${input[1]:?}"
     --env NBDOMAIN \
     --env REALM \
     --env IPADDRESS \
+    --env PREFIXLEN \
     --env SVCPASS \
     --env SVCUSER \
     --hostname=${HOSTNAME:?} \

--- a/imageroot/actions/get-defaults/50read
+++ b/imageroot/actions/get-defaults/50read
@@ -74,6 +74,12 @@ else:
 
 with subprocess.Popen(["ip", "-j", "-4", "address", "show"], stdout=subprocess.PIPE) as proc:
     for iface in json.load(proc.stdout):
+        try:
+            # skip interface without bcast address; wg0 is handled specially
+            if iface["ifname"] != "wg0" and not 'BROADCAST' in iface["flags"]:
+                continue
+        except KeyError:
+            pass
         for ainfo in iface['addr_info']:
             addr = ipm.ip_address(ainfo['local'])
             if addr.is_private and not (addr.is_unspecified or addr.is_reserved or addr.is_loopback or addr.is_link_local):

--- a/imageroot/actions/get-defaults/50read
+++ b/imageroot/actions/get-defaults/50read
@@ -78,17 +78,30 @@ with subprocess.Popen(["ip", "-j", "-4", "address", "show"], stdout=subprocess.P
             # skip interface without bcast address; wg0 is handled specially
             if iface["ifname"] != "wg0" and not 'BROADCAST' in iface["flags"]:
                 continue
+            # skip CNI interfaces
+            if iface["ifname"].startswith('cni-'):
+                continue
         except KeyError:
             pass
+
+        ifip_list = [] # this list collects private ip addresses for iface
         for ainfo in iface['addr_info']:
             addr = ipm.ip_address(ainfo['local'])
             if addr.is_private and not (addr.is_unspecified or addr.is_reserved or addr.is_loopback or addr.is_link_local):
                 altnames = ""
                 if 'altnames' in iface:
                     altnames = f" ({', '.join(iface['altnames'])})"
-                response['ipaddress_list'].append({
+                ifip_list.append({
                     "ipaddress": ainfo['local'],
                     "label": iface['ifname'] + altnames
                 })
+            else:
+                # If the interface has at least a non-private
+                # address, ignore it completely
+                break
+        else:
+            # If the loop completes without breaking, add collected
+            # ip addresses to the response list
+            response['ipaddress_list'] += ifip_list
 
 json.dump(response, fp=sys.stdout)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -40,7 +40,8 @@ elif [[ $provision_type == "join-domain" ]]; then
     samba-tool domain join "${REALM,,}" DC \
         -k yes \
         "--option=bind interfaces only = yes" \
-        "--option=interfaces = 127.0.0.1 ${IPADDRESS}"
+        ${PREFIXLEN:+"--option=disable netbios = yes"} \
+        "--option=interfaces = 127.0.0.1 ${IPADDRESS}${PREFIXLEN:+/}${PREFIXLEN}"
     kdestroy
 elif [[ $provision_type == "new-domain" ]]; then
     echo "Starting domain provisioning procedure..."
@@ -56,7 +57,8 @@ elif [[ $provision_type == "new-domain" ]]; then
         "--domain=${NBDOMAIN}" "--realm=${REALM}" \
         "--host-ip=${IPADDRESS}" \
         "--option=bind interfaces only = yes" \
-        "--option=interfaces = 127.0.0.1 ${IPADDRESS}"
+        ${PREFIXLEN:+"--option=disable netbios = yes"} \
+        "--option=interfaces = 127.0.0.1 ${IPADDRESS}${PREFIXLEN:+/}${PREFIXLEN}"
     if [[ -z "${usebuiltinadmin}" ]]; then
         samba-tool user create "${ADMINUSER}" <<<"${ADMINPASS}"$'\n'"${ADMINPASS}"
         samba-tool user disable administrator


### PR DESCRIPTION
Brief bug description:

Symptom: user and group lists are empty and an error message appears.

If the DC is bound to the wg0 interface IP (e..g. 10.5.4.1) Samba silently fails to bind on that IP.

----

This PR fixes the above bug in smb.conf. It inserts the network prefix to bypass Samba broadcast address discovery, which does not work with wg0 (because it is a point-to-point interface). For wg0, nbt (NetBIOS) name resolver is disabled too.

The PR also filter out IP addresses and interfaces that are known to cause problems:
- `cni-*` interfaces 
- interfaces without broadcast addresses (i.e. point to point)
- interfaces that has at least a public IP
