### PR TITLE
Fix service provider event name

### DIFF
--- a/imageroot/actions/configure-module/80advertise_service
+++ b/imageroot/actions/configure-module/80advertise_service
@@ -46,8 +46,6 @@ data={
     "tls_verify": "off",
     "bind_dn": svcuser + "@" + domain,
     "bind_password": svcpass,
-    "hidden_users": "Guest,krbtgt,ldapservice",
-    "hidden_groups": "DnsUpdateProxy,Domain Computers,Domain Controllers,Domain Guests,Domain Users,Group Policy Creator Owners,Read-only Domain Controllers,Protected Users",
 }
 
 # Advertise this new account provider service instance:


### PR DESCRIPTION
~~Add Redis keys to announce LDAP DB entries we want to hide in UI and applications.~~

Renamed event according to https://nethserver.github.io/ns8-core/modules/service_providers/

----
https://trello.com/c/a2a9oYn2/210-core-p1-hide-builtin-users-and-groups

- https://github.com/NethServer/ns8-mail/pull/35
- https://github.com/NethServer/ns8-core/pull/346
- https://github.com/NethServer/ns8-ldapproxy/pull/6
- https://github.com/NethServer/ns8-samba/pull/7
- https://github.com/NethServer/ns8-openldap/pull/8

