### PR TITLE
Make DC IP routable through cluster VPN

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -46,9 +46,8 @@ buildah add "${container}" imageroot /imageroot
 buildah add "${container}" ui /ui
 buildah config \
     --label "org.nethserver.images=ghcr.io/nethserver/samba-dc:${IMAGETAG:-latest}" \
-    --label 'org.nethserver.authorizations=ldapproxy@node:accountprovider cluster:accountprovider' \
+    --label 'org.nethserver.authorizations=node:fwadm ldapproxy@node:accountprovider cluster:accountprovider' \
     --label 'org.nethserver.flags=core_module account_provider' \
-    --label 'org.nethserver.authorizations=node:fwadm' \
     --entrypoint=/ "${container}"
 buildah commit "${container}" "${repobase}/${reponame}"
 images+=("${repobase}/${reponame}")

--- a/imageroot/actions/configure-module/70update_routes
+++ b/imageroot/actions/configure-module/70update_routes
@@ -25,6 +25,7 @@ import agent.tasks
 import os
 import sys
 import json
+import ipaddress as ipm
 
 #
 # Check if routes for this new DC must be added automatically
@@ -32,41 +33,21 @@ import json
 
 realm = os.environ['REALM']
 node_id = int(os.environ['NODE_ID'])
-ip_address = os.environ['IPADDRESS']
-
-dcs = set()
-destinations = set()
 
 rdb = agent.redis_connect()
-for kenv in rdb.scan_iter(match='module/samba*/environment'):
-    penv = rdb.hgetall(kenv)
-    if penv.get('REALM') != realm:
-        continue # skip DCs of other realms
 
-    # Collect DC IP addresses, excluding the new DC
-    if penv['IPADDRESS'] != ip_address:
-        dcs |= { penv['IPADDRESS'] + '/32' }
+oip_address = ipm.ip_address(os.environ['IPADDRESS'])
+ocluster_network = ipm.ip_network(rdb.get('cluster/network'), strict=False)
 
-for kvpn in rdb.scan_iter(match='node/*/vpn'):
-    cvpn = rdb.hgetall(kvpn)
-
-    # Collect IP addresses routed through the cluster VPN
-    destinations |= {*cvpn.get('destinations', '').split()}
-
-# Check if dcs is a non-empty subset of destinations AND
-# Check if the new DC address is not already in destinations
-if len(dcs) > 0 and dcs <= destinations and not (ip_address + '/32') in destinations:
-    # Cluster VPN routes are added only if all other DCs
-    # already do so.
+if not oip_address in ocluster_network:
     update_routes_result = agent.tasks.run(
         agent_id='cluster',
         action='update-routes',
         data={
             'add': [{
-                "network": ip_address + '/32',
+                "ip_address": os.environ['IPADDRESS'],
                 "node_id": node_id,
             }],
         },
     )
     agent.assert_exp(update_routes_result['exit_code'] == 0)
-    print(f"DCs traffic is routed through the cluster VPN. Other DCs can now can reach {ip_address}", file=sys.stderr)


### PR DESCRIPTION
- IP of LAN must be reachable from other DCs of the cluster.
- Fix the update-routes to use the new API format.
- Simplify the step implementation: each DC just pushes its own IP.


Requires https://github.com/NethServer/ns8-core/pull/362