### PR TITLE
Fix firewall for import-module and restore-module

### DIFF
--- a/imageroot/actions/create-module/70firewall
+++ b/imageroot/actions/create-module/70firewall
@@ -7,6 +7,7 @@
 
 import os
 import agent
+
 agent.assert_exp(agent.add_public_service(os.environ['MODULE_ID'], [
     "53/tcp", "53/udp", # DNS
     "88/tcp", "88/udp", # Kerberos
@@ -20,6 +21,6 @@ agent.assert_exp(agent.add_public_service(os.environ['MODULE_ID'], [
     "464/tcp", "464/udp", # Kerberos kpasswd
     "636/tcp", # LDAPS
     "3268/tcp", # Global Catalog
-    "3269/tcp", #Global Catalog SSL
+    "3269/tcp", # Global Catalog SSL
     "49152-65535/tcp" # Dynamic RPC Ports
     ]))


### PR DESCRIPTION
Open firewall ports within module creation to ensure ports are open in any case.