### PR TITLE
Grant read ACL access to DCs after migration

### DIFF
--- a/samba-dc/usr/local/sbin/rsyncd-import-shares
+++ b/samba-dc/usr/local/sbin/rsyncd-import-shares
@@ -74,3 +74,7 @@ while IFS=$'\t' read -r sharename description; do
     net conf setparm "${sharename}" 'acl_xattr:ignore system acls' no
     echo "Enabled share ${sharename}"
 done
+
+# Grant ACL read privileges to domain controllers:
+shopt -s nullglob
+echo "${SAMBA_SHARES_DIR}"/* | xargs -r -- setfacl -m group:"domain controllers":rx


### PR DESCRIPTION
At the end of the shares import, add read access to "Domain Controllers" to make ACLs visible in the UI.

See https://trello.com/c/u6a71xUa/425-samba-p1-empty-acl-list-after-migration