### PR TITLE
Add scripts to manage Samba DC service based on domain change event

### DIFF
--- a/imageroot/bin/print-bound-domain-list
+++ b/imageroot/bin/print-bound-domain-list
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import json
+import agent
+import agent.tasks
+import os
+import json
+
+
+agent_install_dir = os.environ['AGENT_INSTALL_DIR']
+# realm is mandatory we do not need to test it
+realm = os.environ["REALM"].lower()
+
+# Connect to redis and iterate over the keys, values of cluster/module_domains
+with agent.redis_connect(use_replica=True) as rdb:
+    modules_set = set()
+    for key, value in rdb.hscan_iter("cluster/module_domains"):
+        # Iterate over the value and push each keys into modules_set
+        for element in value.split():
+            if element.lower() == realm:
+                modules_set.add(key)
+# Write modules set to a JSON file
+data = {"domain": realm,"services": list(modules_set)}
+
+with open(f'{agent_install_dir}/api-moduled/public/config.json', 'w') as file:
+    json.dump(data, file)

--- a/imageroot/events/module-domain-changed/10reload_services
+++ b/imageroot/events/module-domain-changed/10reload_services
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+import os
+import sys
+import json
+import agent
+
+
+
+event = json.load(sys.stdin)
+if not os.environ["REALM"].lower() in [domain.lower() for domain in event["domains"]]:
+    sys.exit(0)
+
+agent.run_helper('systemctl', '--user', 'try-reload-or-restart', 'samba-dc.service').check_returncode()


### PR DESCRIPTION
This pull request adds two scripts: "print-bound-domain-list" and "10reload_services" to manage the Samba DC service based on a domain change event. The "print-bound-domain-list" script prints the bound domain list, while the "10reload_services" script reloads the Samba DC service when a domain change event occurs.