### PR TITLE
Allow starting domain name or FQDN with a numeric

### DIFF
--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -79,7 +79,7 @@
         "realm": {
             "type": "string",
             "title": "Domain name",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z][-a-zA-Z0-9]{0,62})+$",
+            "pattern": "^[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+$",
             "maxLength": 140,
             "minLength": 1
         },


### PR DESCRIPTION
This pull request updates the regular expression pattern in the `validate-input.json` file to allow domain names or fully qualified domain names (FQDNs) to start with a numeric character. This change ensures that the validation of domain names is more flexible and aligns with common naming conventions.

https://github.com/NethServer/dev/issues/6887