### PR TITLE
fix(migration): handle space in share name

### DIFF
--- a/samba-dc/usr/local/sbin/rsyncd-import-shares
+++ b/samba-dc/usr/local/sbin/rsyncd-import-shares
@@ -77,4 +77,4 @@ done
 
 # Grant ACL read privileges to domain controllers:
 shopt -s nullglob
-echo "${SAMBA_SHARES_DIR}"/* | xargs -r -- setfacl -m group:"domain controllers":rx
+printf '%s\0' "${SAMBA_SHARES_DIR}"/* | xargs -0 -r -- setfacl -m group:"domain controllers":rx


### PR DESCRIPTION
If the share name contains a space, the final setfacl command fails because it cannot match the correct directory name.

This fix improves the iteration logic over share names using NUL char as item separator instead of spaces and newlines.

https://github.com/NethServer/dev/issues/7295