### PR TITLE
Specify object types for group member management

### DIFF
--- a/imageroot/actions/add-group/50add_group
+++ b/imageroot/actions/add-group/50add_group
@@ -44,7 +44,7 @@ subprocess.run(addgroup_cmd, stdout=sys.stderr, check=True, text=True)
 if users:
     addmembers_cmd = [
         'podman', 'exec', 'samba-dc', 'samba-tool',
-        'group', 'addmembers', group, ','.join(users),
+        'group', 'addmembers', group, ','.join(users), '--object-types=user'
     ]
 
     subprocess.run(addmembers_cmd, stdout=sys.stderr, check=True, text=True)

--- a/imageroot/actions/alter-group/50alter_group
+++ b/imageroot/actions/alter-group/50alter_group
@@ -39,8 +39,8 @@ if 'users' in request:
 
     add_members = new_members - old_members
     if add_members:
-        subprocess.run(sambatool_cmd + ['group', "addmembers", group, ','.join(add_members)], stdout=sys.stderr, check=True, text=True)
+        subprocess.run(sambatool_cmd + ['group', "addmembers", group, ','.join(add_members), '--object-types=user'], stdout=sys.stderr, check=True, text=True)
 
     rem_members = old_members - new_members
     if rem_members:
-        subprocess.run(sambatool_cmd + ['group', "removemembers", group, ','.join(rem_members)], stdout=sys.stderr, check=True, text=True)
+        subprocess.run(sambatool_cmd + ['group', "removemembers", group, ','.join(rem_members), '--object-types=user'], stdout=sys.stderr, check=True, text=True)


### PR DESCRIPTION
Enhance group member management by specifying object types when adding or removing members from a group. This change improves clarity and ensures proper handling of user objects.

https://github.com/NethServer/dev/issues/7286