### PR TITLE
Check for user name conflicts with existing groups during validation

### DIFF
--- a/imageroot/actions/add-group/01validate_group
+++ b/imageroot/actions/add-group/01validate_group
@@ -32,7 +32,16 @@ group = request['group']
 
 testexists_cmd = ['podman', 'exec', '-i', 'samba-dc', 'samba-tool', 'group', 'show', group]
 proc = subprocess.run(testexists_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
+
+# we test if the group does not have the same name than a user
+testnameavailable_cmd = ['podman', 'exec', '-i', 'samba-dc', 'samba-tool', 'user', 'show', group]
+user = subprocess.run(testnameavailable_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
+
 if proc.returncode == 0:
     agent.set_status('validation-failed')
     json.dump([{'field':'group', 'parameter':'group','value': group, 'error':'group_already_exists'}], fp=sys.stdout)
+    sys.exit(2)
+elif user.returncode == 0:
+    agent.set_status('validation-failed')
+    json.dump([{'field':'group', 'parameter':'group','value': group, 'error':'user_with_same_name'}], fp=sys.stdout)
     sys.exit(2)

--- a/imageroot/actions/add-group/01validate_group
+++ b/imageroot/actions/add-group/01validate_group
@@ -32,16 +32,15 @@ group = request['group']
 
 testexists_cmd = ['podman', 'exec', '-i', 'samba-dc', 'samba-tool', 'group', 'show', group]
 proc = subprocess.run(testexists_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
-
-# we test if the group does not have the same name than a user
-testnameavailable_cmd = ['podman', 'exec', '-i', 'samba-dc', 'samba-tool', 'user', 'show', group]
-user = subprocess.run(testnameavailable_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
-
 if proc.returncode == 0:
     agent.set_status('validation-failed')
     json.dump([{'field':'group', 'parameter':'group','value': group, 'error':'group_already_exists'}], fp=sys.stdout)
     sys.exit(2)
-elif user.returncode == 0:
+
+# we test if the group does not have the same name than a user
+testnameavailable_cmd = ['podman', 'exec', '-i', 'samba-dc', 'samba-tool', 'user', 'show', group]
+testnameavailable_proc = subprocess.run(testnameavailable_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
+if testnameavailable_proc.returncode == 0:
     agent.set_status('validation-failed')
     json.dump([{'field':'group', 'parameter':'group','value': group, 'error':'user_with_same_name'}], fp=sys.stdout)
     sys.exit(2)

--- a/imageroot/actions/add-user/01validate_user
+++ b/imageroot/actions/add-user/01validate_user
@@ -32,16 +32,15 @@ user = request['user']
 
 testexists_cmd = ['podman', 'exec', '-i', 'samba-dc', 'samba-tool', 'user', 'show', user]
 proc = subprocess.run(testexists_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
-
-# we test if the user does not have the same name than a group
-testnameavailable_cmd = ['podman', 'exec', '-i', 'samba-dc', 'samba-tool', 'group', 'show', user]
-group = subprocess.run(testnameavailable_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
-
 if proc.returncode == 0:
     agent.set_status('validation-failed')
     json.dump([{'field':'user', 'parameter':'user','value': user, 'error':'user_already_exists'}], fp=sys.stdout)
     sys.exit(2)
-elif group.returncode == 0:
+
+# we test if the user does not have the same name than a group
+testnameavailable_cmd = ['podman', 'exec', '-i', 'samba-dc', 'samba-tool', 'group', 'show', user]
+testnameavailable_proc = subprocess.run(testnameavailable_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
+if testnameavailable_proc.returncode == 0:
     agent.set_status('validation-failed')
     json.dump([{'field':'user', 'parameter':'user','value': user, 'error':'group_with_same_name'}], fp=sys.stdout)
     sys.exit(2)

--- a/imageroot/actions/add-user/01validate_user
+++ b/imageroot/actions/add-user/01validate_user
@@ -32,7 +32,16 @@ user = request['user']
 
 testexists_cmd = ['podman', 'exec', '-i', 'samba-dc', 'samba-tool', 'user', 'show', user]
 proc = subprocess.run(testexists_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
+
+# we test if the user does not have the same name than a group
+testnameavailable_cmd = ['podman', 'exec', '-i', 'samba-dc', 'samba-tool', 'group', 'show', user]
+group = subprocess.run(testnameavailable_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
+
 if proc.returncode == 0:
     agent.set_status('validation-failed')
     json.dump([{'field':'user', 'parameter':'user','value': user, 'error':'user_already_exists'}], fp=sys.stdout)
+    sys.exit(2)
+elif group.returncode == 0:
+    agent.set_status('validation-failed')
+    json.dump([{'field':'user', 'parameter':'user','value': user, 'error':'group_with_same_name'}], fp=sys.stdout)
     sys.exit(2)


### PR DESCRIPTION
Implement validation to prevent user name conflicts when adding a group and ensure that user names do not match existing group names.

https://github.com/NethServer/dev/issues/7322