### PR TITLE
feat: require core 3.6.3+

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -84,7 +84,7 @@ buildah add "${container}" ns8-user-manager-${user_manager_version}.tar.gz /imag
 buildah add "${container}" ui/dist /ui
 buildah config \
     --label="org.nethserver.max-per-node=1" \
-    --label="org.nethserver.min-core=3.3.0-0" \
+    --label="org.nethserver.min-core=3.6.3-0" \
     --label "org.nethserver.images=ghcr.io/nethserver/samba-dc:${IMAGETAG:-latest}" \
     --label 'org.nethserver.authorizations=node:fwadm ldapproxy@node:accountprovider cluster:accountprovider traefik@node:routeadm' \
     --label="org.nethserver.tcp-ports-demand=1" \


### PR DESCRIPTION
Core 3.6.3 implements a new behavior for agent.add_public_service() required to extend the Samba public ports list with new WSDD port requirements. See https://github.com/NethServer/ns8-core/pull/850.

Refs NethServer/dev#7372