### PR TITLE
Set browseable to true in shared folder modal

### DIFF
--- a/ui/src/components/shared-folders/CreateSharedFolderModal.vue
+++ b/ui/src/components/shared-folders/CreateSharedFolderModal.vue
@@ -309,7 +309,7 @@ export default {
         this.enable_recycle = false;
         this.recycle_retention = "30";
         this.recycle_retention_radio = "limited";
-        this.browseable = false;
+        this.browseable = true;
         this.enable_audit = false;
         this.log_failed_events = false;
         this.recycle_versions = "last";


### PR DESCRIPTION
Update the shared folder modal to set the browseable property to true, enhancing user experience.

https://github.com/NethServer/dev/issues/7390
https://github.com/NethServer/dev/issues/7386