### PR TITLE
Set minimum password age to 0 days

### DIFF
--- a/samba-dc/usr/local/sbin/new-domain
+++ b/samba-dc/usr/local/sbin/new-domain
@@ -34,3 +34,6 @@ fi
 samba-tool user setexpiry --noexpiry "${adminuser}"
 samba-tool user create "${SVCUSER}" <<<"${SVCPASS}"$'\n'"${SVCPASS}"
 samba-tool user setexpiry --noexpiry "${SVCUSER}"
+
+# set the minimum password age to 0 days #7400
+samba-tool domain passwordsettings set --min-pwd-age=0


### PR DESCRIPTION
Configure the minimum password age to allow immediate password changes. For existing domain, the sysadmin could set the --min-pwd-age=0 by the `Edit password policy`

![image](https://github.com/user-attachments/assets/3e168cae-cfbe-4c3f-95c5-c61edaf71772)


https://github.com/NethServer/dev/issues/7400