### PR TITLE
Add metrics provisioning to update-module.d

### DIFF
--- a/imageroot/actions/set-ipaddress/80provision_metrics
+++ b/imageroot/actions/set-ipaddress/80provision_metrics
@@ -1,0 +1,1 @@
+../actions/configure-module/80provision_metrics

--- a/imageroot/update-module.d/80advertise_service
+++ b/imageroot/update-module.d/80advertise_service
@@ -1,1 +1,0 @@
-../actions/configure-module/80advertise_service


### PR DESCRIPTION
Add metrics provisioning to update-module.d to add the samba audit modules to Grafana dashboard during update.

NethServer/dev#7542