### PR TITLE
Default password expiration policy is disabled

### DIFF
--- a/samba-dc/usr/local/sbin/new-domain
+++ b/samba-dc/usr/local/sbin/new-domain
@@ -35,5 +35,6 @@ samba-tool user setexpiry --noexpiry "${adminuser}"
 samba-tool user create "${SVCUSER}" <<<"${SVCPASS}"$'\n'"${SVCPASS}"
 samba-tool user setexpiry --noexpiry "${SVCUSER}"
 
-# Default password expiration policy is disabled
-samba-tool domain passwordsettings set --max-pwd-age=0
+# Default password expiration policy is disabled #7503
+# set the minimum password age to 0 days #7400
+samba-tool domain passwordsettings set --min-pwd-age=0 --max-pwd-age=0

--- a/samba-dc/usr/local/sbin/new-domain
+++ b/samba-dc/usr/local/sbin/new-domain
@@ -34,3 +34,6 @@ fi
 samba-tool user setexpiry --noexpiry "${adminuser}"
 samba-tool user create "${SVCUSER}" <<<"${SVCPASS}"$'\n'"${SVCPASS}"
 samba-tool user setexpiry --noexpiry "${SVCUSER}"
+
+# Default password expiration policy is disabled
+samba-tool domain passwordsettings set --max-pwd-age=0


### PR DESCRIPTION
Disable by default the expiration policy for new domain, set also the minimal age to 0 to fix #7400
NethServer/dev#7503
https://github.com/NethServer/dev/issues/7400