### PR TITLE
Modify Samba users' flags from [UX] to [U] excluding ldapservice

### DIFF
--- a/imageroot/actions/import-module/75fix_pdbedit_flags
+++ b/imageroot/actions/import-module/75fix_pdbedit_flags
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+exec 1>&2
+set -e
+
+# This script modifies all users with the [UX] flag to [U] in a Samba domain.
+# It excludes the 'ldapservice' user from modification.
+# see issue https://github.com/NethServer/dev/issues/7558
+
+changed=0
+for user in $(podman exec samba-dc pdbedit -L | cut -d: -f1); do
+    # Ignore ldapservice
+    if [ "$user" = "ldapservice" ]; then
+        echo "ldapservice user ignored."
+        continue
+    fi
+    # Try to get flags for this user, suppress error output for nobody
+    flags=$(podman exec samba-dc pdbedit -v "$user" 2>/dev/null | grep "Account Flags:" | awk '{print $3}')
+    if [[ "$flags" == [UX* ]]; then
+        echo "Modifying user: $user - Flags before: $flags]"
+        podman exec samba-dc pdbedit -r "$user" -c "[]" > /dev/null 2>&1
+        changed=1
+    fi
+done
+
+if [[ $changed -eq 0 ]]; then
+    echo "No user with the [UX] flag found (excluding ldapservice). Nothing to do."
+else
+    echo "All users (excluding ldapservice) with the [UX] flag have been changed to [U]."
+fi


### PR DESCRIPTION
Add a script that updates Samba users with the [UX] flag to [U], while ensuring the 'ldapservice' user remains unchanged. This addresses issue #7558.

https://github.com/NethServer/dev/issues/7558

The `X` flag comes from the migration of NS7, NS8 does not use this flag, only `U` for users, see https://github.com/NethServer/dev/issues/7558#issuecomment-3182910734

Questions
- For now we fix only the migration but we could try to fix domains already migrated with upgrade's action
- [The administrator in NS8 is set with a never expire ](https://github.com/NethServer/ns8-samba/blob/9d25a1aa4df454c0527e0943ca97a2e29c356e5d/samba-dc/usr/local/sbin/new-domain#L34) but the migrated admin and administrator can expire when they are migrated from NS7, do we need to fix them and set them with `no expiration`


 what do you think @DavidePrincipi 

