### PR TITLE
Allow subprocess.run to modify user mail without error checking

### DIFF
--- a/imageroot/api-moduled/handlers/alter-user/post
+++ b/imageroot/api-moduled/handlers/alter-user/post
@@ -71,6 +71,6 @@ if 'mail' in request:
     else:
         ldbedit_cmd = ['podman', 'exec', '-i', 'samba-dc', 'ldbmodify', '-H', '/var/lib/samba/private/sam.ldb']
         ldbedit_input = f'{dn}\nchangetype: modify\ndelete: mail\n'
-    subprocess.run(ldbedit_cmd, input=ldbedit_input, stdout=sys.stderr, check=True, text=True)
+    subprocess.run(ldbedit_cmd, input=ldbedit_input, stdout=sys.stderr, check=False, text=True)
 
 json.dump({"status": "success", "message": "user_altered"}, fp=sys.stdout)


### PR DESCRIPTION
Change the subprocess.run call to not check for errors when modifying user mail, ensuring smoother execution in this context.

https://github.com/NethServer/dev/issues/7613