### PR TITLE
New API for password expiration information

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,21 +7,21 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN set -e \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        samba=2:4.19.5+dfsg-4ubuntu9.4 \
-        samba-ad-dc=2:4.19.5+dfsg-4ubuntu9.4 \
-        samba-ad-provision=2:4.19.5+dfsg-4ubuntu9.4 \
-        winbind=2:4.19.5+dfsg-4ubuntu9.4 \
+        samba=2:4.19.5+dfsg-4ubuntu9.6 \
+        samba-ad-dc=2:4.19.5+dfsg-4ubuntu9.6 \
+        samba-ad-provision=2:4.19.5+dfsg-4ubuntu9.6 \
+        winbind=2:4.19.5+dfsg-4ubuntu9.6 \
         krb5-user=1.20.1-6ubuntu2.6 \
         iputils-ping=3:20240117-1ubuntu0.1 \
         bzip2=1.0.8-5.1build0.1 \
-        ldb-tools=2:2.8.0+samba4.19.5+dfsg-4ubuntu9.4 \
+        ldb-tools=2:2.8.0+samba4.19.5+dfsg-4ubuntu9.6 \
         chrony=4.5-1ubuntu4.2 \
-        bind9-dnsutils=1:9.18.39-0ubuntu0.24.04.3 \
+        bind9-dnsutils=1:9.18.39-0ubuntu0.24.04.5 \
         acl=2.3.2-1build1.1 \
         attr=1:2.5.2-1build1.1 \
-        smbclient=2:4.19.5+dfsg-4ubuntu9.4 \
-        libnss-winbind=2:4.19.5+dfsg-4ubuntu9.4 \
-        rsync=3.2.7-1ubuntu1.2 \
+        smbclient=2:4.19.5+dfsg-4ubuntu9.6 \
+        libnss-winbind=2:4.19.5+dfsg-4ubuntu9.6 \
+        rsync=3.2.7-1ubuntu1.5 \
         plocate=1.1.19-2ubuntu2 \
         wsdd=2:0.7.1-5 \
         syslog-ng-core=4.3.1-2build5 \

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ API implementation files are located under
 `.json` files in that directory define API schemas (input/output) using
 JSON Schema. These files describe the request and response formats.
 
+The generated OpenAPI document is available at
+`imageroot/api-moduled/openapi.yaml`.
+
 ## File Server
 
 Any Samba instance (whether its role is `dc` or `member`) can act as a

--- a/imageroot/api-moduled/handlers/get-password-expiration/post
+++ b/imageroot/api-moduled/handlers/get-password-expiration/post
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import os
+import sys
+
+import samba
+
+request = json.load(sys.stdin)
+
+try:
+    info = samba.get_user_password_expiration(os.environ["JWT_ID"])
+except KeyError:
+    json.dump(
+        {
+            "status": "failure",
+            "message": "user_not_found",
+            "expired": False,
+            "expiration": None,
+            "must_change": False,
+        },
+        fp=sys.stdout,
+    )
+    sys.exit(0)
+
+json.dump(
+    {
+        "status": "success",
+        "message": "password_expiration",
+        **info,
+    },
+    fp=sys.stdout,
+)

--- a/imageroot/api-moduled/handlers/get-password-expiration/validate-input.json
+++ b/imageroot/api-moduled/handlers/get-password-expiration/validate-input.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "get-password-expiration input",
+    "$id": "http://schema.nethserver.org/ns8-samba/api-moduled/handlers/get-password-expiration/validate-input.json",
+    "type": "object",
+    "additionalProperties": false
+}

--- a/imageroot/api-moduled/handlers/get-password-expiration/validate-output.json
+++ b/imageroot/api-moduled/handlers/get-password-expiration/validate-output.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "get-password-expiration output",
+    "$id": "http://schema.nethserver.org/ns8-samba/api-moduled/handlers/get-password-expiration/validate-output.json",
+    "type": "object",
+    "required": [
+        "status",
+        "message",
+        "expired",
+        "expiration",
+        "must_change"
+    ],
+    "properties": {
+        "status": {
+            "enum": [
+                "success",
+                "failure"
+            ]
+        },
+        "message": {
+            "type": "string"
+        },
+        "expired": {
+            "type": "boolean"
+        },
+        "expiration": {
+            "anyOf": [
+                {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "must_change": {
+            "type": "boolean"
+        }
+    }
+}

--- a/imageroot/api-moduled/handlers/get-password-policy/post
+++ b/imageroot/api-moduled/handlers/get-password-policy/post
@@ -6,39 +6,10 @@
 #
 
 import json
-import re
-import subprocess
+import samba
 import sys
 
-result = subprocess.run(['podman', 'exec', 'samba-dc', 'samba-tool', 'domain', 'passwordsettings', 'show'],
-                        check=True, capture_output=True, text=True)
-
-password_settings = {
-    'expiration': {
-        'max_age': int(re.search(r'Maximum password age \(days\): (\d.*)\n', result.stdout).group(1)),
-        'min_age': int(re.search(r'Minimum password age \(days\): (\d.*)\n', result.stdout).group(1))
-    },
-    'strength': {
-        'history_length': int(re.search(r'Password history length: (\d.*)\n', result.stdout).group(1)),
-        'password_min_length': int(re.search(r'Minimum password length: (\d.*)\n', result.stdout).group(1)),
-        'complexity_check': re.search(r'Password complexity: (.*)\n', result.stdout).group(1) == 'on'
-    }
-}
-
-password_settings['expiration']['enforced'] = password_settings['expiration']['max_age'] > 0 or \
-                                              password_settings['expiration']['min_age'] > 0
-password_settings['strength']['enforced'] = password_settings['strength']['history_length'] > 0 or \
-                                            password_settings['strength']['password_min_length'] > 0 or \
-                                            password_settings['strength']['complexity_check']
-
-if not password_settings['expiration']['enforced']:
-    password_settings['expiration']['max_age'] = 180
-    password_settings['expiration']['min_age'] = 0
-
-if not password_settings['strength']['enforced']:
-    password_settings['strength']['history_length'] = 24
-    password_settings['strength']['password_min_length'] = 8
-    password_settings['strength']['complexity_check'] = True
+password_settings = samba.get_password_settings()
 
 json.dump({
     "status": "success",

--- a/imageroot/api-moduled/handlers/login/post
+++ b/imageroot/api-moduled/handlers/login/post
@@ -48,11 +48,11 @@ def ad_login(request):
         if "Password expired.  You must change it now." in proc_kinit.stdout:
             # Password must be changed immediately: return a token limited to
             # password changing:
-            oclaims["scope"] = ["change-password", "get-password-policy"]
+            oclaims["scope"] = ["change-password", "get-password-policy", "get-password-expiration"]
         else:
             sys.exit(3) # Login failed
     if "Domain Admins" not in oclaims["groups"]:
-        oclaims["scope"] = ["change-password", "get-password-policy"]
+        oclaims["scope"] = ["change-password", "get-password-policy", "get-password-expiration"]
     # Clean up the cache file after a successful login:
     subprocess.run(["podman", "exec", "samba-dc", "rm", "-f", cache_file], text=True, capture_output=True)
     return oclaims
@@ -97,6 +97,7 @@ def api_server_login(request):
             "remove-group",
             "export-users",
             "import-users",
+            "get-password-expiration",
             "list-users",
             "list-groups",
         ],

--- a/imageroot/api-moduled/openapi.yaml
+++ b/imageroot/api-moduled/openapi.yaml
@@ -1,0 +1,1487 @@
+openapi: 3.1.0
+info:
+  title: ns8-samba api-moduled API
+  version: 1.0.0
+  description: 'OpenAPI description of the HTTP API implemented by `imageroot/api-moduled/handlers/`
+    plus the built-in `api-moduled` authentication endpoints. This specification is
+    derived from the handler scripts, their JSON schemas, and the upstream `api-moduled`
+    request/response contract.
+
+
+    Operation-level failures are not uniform across handlers: some handlers return
+    HTTP 200 with `{ "status": "failure", ... }`, while unhandled helper failures
+    surface as HTTP 500 from `api-moduled`.'
+externalDocs:
+  description: api-moduled upstream documentation
+  url: https://github.com/NethServer/ns8-core/tree/main/core/api-moduled
+servers:
+- url: https://{host}/users-admin/{domain}/api
+  description: Public users-admin endpoint exposed by ns8-samba
+  variables:
+    host:
+      default: localhost
+    domain:
+      default: domain.test
+- url: http://{host}:9313/api
+  description: Direct local api-moduled listener
+  variables:
+    host:
+      default: localhost
+tags:
+- name: Authentication
+- name: Users
+- name: Groups
+- name: Password policy
+- name: Administration
+- name: Configuration
+paths:
+  /auth:
+    get:
+      tags:
+      - Authentication
+      summary: Validate credentials with HTTP Basic authentication
+      description: Checks credentials by invoking the `login` handler protocol without
+        issuing a JWT.
+      operationId: basicAuth
+      security:
+      - basicAuth: []
+      responses:
+        '200':
+          description: Credentials are valid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicAuthSuccessResponse'
+        '401':
+          description: Credentials are invalid or missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginFailureResponse'
+  /login:
+    post:
+      tags:
+      - Authentication
+      summary: Authenticate and obtain a JWT
+      description: The backing handler accepts AD user credentials by default, or
+        cluster-admin credentials when `auth_backend` is set to `api-server`. Non-Domain
+        Admin AD users receive a restricted token scope that only allows `change-password`,
+        `get-password-policy`, and `get-password-expiration`.
+      operationId: login
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+      responses:
+        '200':
+          description: Authentication succeeded and a JWT was issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginSuccessResponse'
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginFailureResponse'
+        '500':
+          description: The login handler or JWT middleware failed internally
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /logout:
+    post:
+      tags:
+      - Authentication
+      summary: Invalidate the current login session
+      description: JWT authentication is required. The default `api-moduled` logout
+        response only includes a `code` field.
+      operationId: logout
+      security:
+      - bearerAuth: []
+      responses:
+        '200':
+          description: Logout succeeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogoutResponse'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+  /add-group:
+    post:
+      tags:
+      - Groups
+      - Administration
+      summary: Create a group
+      operationId: addGroup
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddGroupRequest'
+      responses:
+        '200':
+          description: The group was created, or the handler returned a structured
+            duplicate-group failure
+          content:
+            application/json:
+              schema:
+                oneOf:
+                - $ref: '#/components/schemas/AddGroupSuccessResponse'
+                - $ref: '#/components/schemas/DuplicateGroupResponse'
+        '400':
+          description: Input schema validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed without a structured JSON response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /add-user:
+    post:
+      tags:
+      - Users
+      - Administration
+      summary: Create a user
+      operationId: addUser
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddUserRequest'
+      responses:
+        '200':
+          description: The user was created, or the handler returned a structured
+            duplicate-user failure
+          content:
+            application/json:
+              schema:
+                oneOf:
+                - $ref: '#/components/schemas/AddUserSuccessResponse'
+                - $ref: '#/components/schemas/DuplicateUserResponse'
+        '400':
+          description: Input schema validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed without a structured JSON response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /alter-group:
+    post:
+      tags:
+      - Groups
+      - Administration
+      summary: Update a group
+      operationId: alterGroup
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AlterGroupRequest'
+      responses:
+        '200':
+          description: The group was updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlterGroupResponse'
+        '400':
+          description: Input schema validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /alter-user:
+    post:
+      tags:
+      - Users
+      - Administration
+      summary: Update a user
+      description: 'Password-change validation failures are reported as HTTP 200 with
+        `status: failure`; unhandled helper failures still become HTTP 500.'
+      operationId: alterUser
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AlterUserRequest'
+      responses:
+        '200':
+          description: The user was updated, or the handler returned a structured
+            password-policy failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlterUserResponse'
+        '400':
+          description: Input schema validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /change-password:
+    post:
+      tags:
+      - Users
+      - Password policy
+      summary: Change the current user's password
+      description: The current user is derived from `JWT_ID`. This handler is intended
+        for self-service use and is available to restricted user tokens.
+      operationId: changePassword
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangePasswordRequest'
+      responses:
+        '200':
+          description: The password was changed, or the handler returned a structured
+            failure reason
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangePasswordResponse'
+        '400':
+          description: Input schema validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /export-users:
+    post:
+      tags:
+      - Users
+      - Administration
+      summary: Export users
+      description: This handler expects a JSON request body even though it does not
+        consume any parameters. Send `{}`.
+      operationId: exportUsers
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObjectRequest'
+      responses:
+        '200':
+          description: Users were exported
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportUsersResponse'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /get-configuration:
+    post:
+      tags:
+      - Configuration
+      - Administration
+      summary: Read module configuration exposed by the users-admin API
+      description: This handler expects a JSON request body even though it does not
+        consume any parameters. Send `{}`.
+      operationId: getConfiguration
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObjectRequest'
+      responses:
+        '200':
+          description: Configuration was returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetConfigurationResponse'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /get-password-policy:
+    post:
+      tags:
+      - Password policy
+      summary: Read the effective password policy
+      description: This handler expects a JSON request body even though it does not
+        consume any parameters. Send `{}`. It is available to restricted user tokens.
+      operationId: getPasswordPolicy
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObjectRequest'
+      responses:
+        '200':
+          description: Password policy was returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPasswordPolicyResponse'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /get-password-expiration:
+    post:
+      tags:
+      - Password policy
+      summary: Read the current user's password expiration status
+      description: This handler returns only password-expiration-related information
+        for the authenticated user. It is available to normal user tokens as well
+        as admin tokens.
+      operationId: getPasswordExpiration
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObjectRequest'
+      responses:
+        '200':
+          description: Password expiration info was returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPasswordExpirationResponse'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /import-users:
+    post:
+      tags:
+      - Users
+      - Administration
+      summary: Import users
+      description: 'Imports user records and creates missing groups on the fly. The
+        handler reports import-wide failure as HTTP 200 with `status: failure` and
+        `message: import_failed`.'
+      operationId: importUsers
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ImportUsersRequest'
+      responses:
+        '200':
+          description: Users were imported, or the import failed with a structured
+            status payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportUsersResponse'
+        '400':
+          description: Input schema validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed before returning JSON
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /list-groups:
+    post:
+      tags:
+      - Groups
+      - Administration
+      summary: List groups
+      description: This handler expects a JSON request body even though it does not
+        consume any parameters. Send `{}`.
+      operationId: listGroups
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObjectRequest'
+      responses:
+        '200':
+          description: Groups were returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListGroupsResponse'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /list-users:
+    post:
+      tags:
+      - Users
+      - Administration
+      summary: List users
+      description: This handler expects a JSON request body even though it does not
+        consume any parameters. Send `{}`.
+      operationId: listUsers
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmptyObjectRequest'
+      responses:
+        '200':
+          description: Users were returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListUsersResponse'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /remove-group:
+    post:
+      tags:
+      - Groups
+      - Administration
+      summary: Delete a group
+      operationId: removeGroup
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemoveGroupRequest'
+      responses:
+        '200':
+          description: The group was removed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoveGroupResponse'
+        '400':
+          description: Input schema validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+  /remove-user:
+    post:
+      tags:
+      - Users
+      - Administration
+      summary: Delete a user
+      operationId: removeUser
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemoveUserRequest'
+      responses:
+        '200':
+          description: The user was removed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RemoveUserResponse'
+        '400':
+          description: Input schema validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+        '401':
+          description: Missing, invalid, or expired JWT
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        '403':
+          description: Token scope does not allow this handler
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        '500':
+          description: The backing helper failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    ValidationError:
+      type: object
+      required:
+      - parameter
+      - error
+      - value
+      - field
+      properties:
+        parameter:
+          type: string
+        error:
+          type: string
+        value: {}
+        field:
+          type: string
+    BadRequestError:
+      type: object
+      required:
+      - code
+      - status
+      - error
+      properties:
+        code:
+          type: integer
+          enum:
+          - 400
+        status:
+          type: string
+          enum:
+          - Bad request
+        error:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    UnauthorizedError:
+      type: object
+      required:
+      - code
+      - message
+      properties:
+        code:
+          type: integer
+          enum:
+          - 401
+        message:
+          type: string
+    ForbiddenError:
+      type: object
+      required:
+      - code
+      - message
+      properties:
+        code:
+          type: integer
+          enum:
+          - 403
+        message:
+          type: string
+          enum:
+          - you don't have permission to access this resource
+    InternalServerError:
+      type: object
+      required:
+      - code
+      - status
+      properties:
+        code:
+          type: integer
+          enum:
+          - 500
+        status:
+          type: string
+          enum:
+          - Internal server error
+        error:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    EmptyObjectRequest:
+      type: object
+      description: Handlers without parameters still expect a valid JSON document.
+        Use an empty object.
+      examples:
+      - {}
+    Claims:
+      type: object
+      required:
+      - uid
+      - groups
+      properties:
+        uid:
+          type: string
+        groups:
+          type: array
+          items:
+            type: string
+        scope:
+          type: array
+          items:
+            type: string
+          description: If omitted, the token is unrestricted. If present, only the
+            listed handlers are authorized.
+        auth_backend:
+          type: string
+          description: Currently emitted by `auth_backend=api-server` logins.
+      additionalProperties: true
+    LoginRequest:
+      type: object
+      required:
+      - username
+      - password
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+        auth_backend:
+          type: string
+          enum:
+          - ad
+          - api-server
+          default: ad
+    LoginSuccessResponse:
+      type: object
+      required:
+      - code
+      - token
+      - expire
+      - message
+      - claims
+      properties:
+        code:
+          type: integer
+          enum:
+          - 200
+        token:
+          type: string
+        expire:
+          type: string
+          format: date-time
+        message:
+          type: string
+          enum:
+          - login succeeded
+        claims:
+          $ref: '#/components/schemas/Claims'
+    LoginFailureResponse:
+      type: object
+      required:
+      - code
+      - message
+      properties:
+        code:
+          type: integer
+          enum:
+          - 401
+        message:
+          type: string
+          examples:
+          - incorrect Username or Password
+    BasicAuthSuccessResponse:
+      type: object
+      required:
+      - code
+      - message
+      properties:
+        code:
+          type: integer
+          enum:
+          - 200
+        message:
+          type: string
+          enum:
+          - login succeeded
+    LogoutResponse:
+      type: object
+      required:
+      - code
+      properties:
+        code:
+          type: integer
+          enum:
+          - 200
+    StatusResponse:
+      type: object
+      required:
+      - status
+      - message
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+          - failure
+        message:
+          type: string
+    StructuredFailureResponse:
+      type: object
+      required:
+      - status
+      - message
+      - error
+      properties:
+        status:
+          type: string
+          enum:
+          - failure
+        message:
+          type: string
+        error:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    PasswordPolicy:
+      type: object
+      required:
+      - expiration
+      - strength
+      properties:
+        expiration:
+          type: object
+          required:
+          - enforced
+          - max_age
+          - min_age
+          properties:
+            enforced:
+              type: boolean
+            max_age:
+              type: integer
+            min_age:
+              type: integer
+        strength:
+          type: object
+          required:
+          - enforced
+          - history_length
+          - password_min_length
+          - complexity_check
+          properties:
+            enforced:
+              type: boolean
+            history_length:
+              type: integer
+            password_min_length:
+              type: integer
+            complexity_check:
+              type: boolean
+    UserImportExportRecord:
+      type: object
+      required:
+      - user
+      properties:
+        user:
+          type: string
+          minLength: 1
+          maxLength: 255
+          pattern: ^[a-zA-Z][-._a-zA-Z0-9]*$
+        display_name:
+          type: string
+          maxLength: 256
+        password:
+          type: string
+          maxLength: 256
+          description: Accepted on import only; never returned by export.
+        locked:
+          type: boolean
+          description: If true, the account is locked.
+        groups:
+          type: array
+          items:
+            type: string
+        mail:
+          type: string
+        must_change_password:
+          type: boolean
+          description: Accepted for compatibility by import; export always returns
+            `false` in this backend.
+        no_password_expiration:
+          type: boolean
+    ListUserRecord:
+      type: object
+      required:
+      - user
+      - display_name
+      - locked
+      - expired
+      - password_expiration
+      - mail
+      properties:
+        user:
+          type: string
+        display_name:
+          type: string
+        locked:
+          type: boolean
+        expired:
+          type: boolean
+        password_expiration:
+          type: integer
+          description: Unix timestamp, or `-1` when the password does not expire.
+        mail:
+          type: string
+    GroupListRecord:
+      type: object
+      required:
+      - group
+      - description
+      - users
+      properties:
+        group:
+          type: string
+        description:
+          type: string
+        users:
+          type: array
+          items:
+            type: string
+    AddGroupRequest:
+      type: object
+      required:
+      - group
+      - users
+      properties:
+        group:
+          type: string
+          minLength: 1
+        description:
+          type: string
+          maxLength: 256
+        users:
+          type: array
+          items:
+            type: string
+            minLength: 1
+    AddGroupSuccessResponse:
+      type: object
+      required:
+      - status
+      - message
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+        message:
+          type: string
+          enum:
+          - group_created
+    DuplicateGroupResponse:
+      allOf:
+      - $ref: '#/components/schemas/StructuredFailureResponse'
+      - properties:
+          message:
+            type: string
+            description: Currently emitted as an empty string by the handler.
+    AddUserRequest:
+      type: object
+      required:
+      - user
+      properties:
+        user:
+          type: string
+          minLength: 1
+          maxLength: 255
+          pattern: ^[a-zA-Z][-._a-zA-Z0-9]*$
+        display_name:
+          type: string
+          maxLength: 256
+        password:
+          type: string
+          maxLength: 256
+          description: If omitted or empty, the helper generates a random password.
+        locked:
+          type: boolean
+        groups:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            minLength: 1
+        no_password_expiration:
+          type: boolean
+        mail:
+          oneOf:
+          - type: string
+            format: email
+          - type: string
+            maxLength: 0
+    AddUserSuccessResponse:
+      type: object
+      required:
+      - status
+      - message
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+        message:
+          type: string
+          enum:
+          - user_created
+    DuplicateUserResponse:
+      allOf:
+      - $ref: '#/components/schemas/StructuredFailureResponse'
+      - properties:
+          message:
+            type: string
+            description: Currently emitted as an empty string by the handler.
+    AlterGroupRequest:
+      type: object
+      required:
+      - group
+      properties:
+        group:
+          type: string
+          minLength: 1
+        description:
+          type: string
+          maxLength: 256
+        users:
+          type: array
+          items:
+            type: string
+            minLength: 1
+    AlterGroupResponse:
+      type: object
+      required:
+      - status
+      - message
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+        message:
+          type: string
+          enum:
+          - group_altered
+    AlterUserRequest:
+      type: object
+      required:
+      - user
+      properties:
+        user:
+          type: string
+          minLength: 1
+        display_name:
+          type: string
+          maxLength: 256
+        password:
+          type: string
+          maxLength: 256
+          description: If present and empty, the helper generates a random password.
+        groups:
+          type: array
+          items:
+            type: string
+            minLength: 1
+        locked:
+          type: boolean
+        no_password_expiration:
+          type: boolean
+        mail:
+          oneOf:
+          - type: string
+            format: email
+          - type: string
+            maxLength: 0
+    AlterUserResponse:
+      type: object
+      required:
+      - status
+      - message
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+          - failure
+        message:
+          type: string
+          enum:
+          - password_changed
+          - error_password_complexity
+          - error_password_history
+          - error_password_same
+          - error_unknown
+    ChangePasswordRequest:
+      type: object
+      required:
+      - current_password
+      - new_password
+      properties:
+        current_password:
+          type: string
+        new_password:
+          type: string
+    ChangePasswordResponse:
+      type: object
+      required:
+      - status
+      - message
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+          - failure
+        message:
+          type: string
+          enum:
+          - password_changed
+          - user_not_found
+          - error_invalid_credentials
+          - error_password_complexity
+          - error_password_length
+          - error_password_history
+          - error_password_minimum_age
+          - error_unknown
+    ExportUsersResponse:
+      type: object
+      required:
+      - status
+      - message
+      - records
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+        message:
+          type: string
+          enum:
+          - export_users
+        records:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserImportExportRecord'
+    GetConfigurationResponse:
+      type: object
+      required:
+      - status
+      - message
+      - config
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+        message:
+          type: string
+          enum:
+          - configuration_listed
+        config:
+          type: object
+          required:
+          - password_settings
+          properties:
+            password_settings:
+              $ref: '#/components/schemas/PasswordPolicy'
+    GetPasswordPolicyResponse:
+      type: object
+      required:
+      - status
+      - message
+      - policy
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+        message:
+          type: string
+          enum:
+          - password_policy
+        policy:
+          $ref: '#/components/schemas/PasswordPolicy'
+    GetPasswordExpirationResponse:
+      type: object
+      required:
+      - status
+      - message
+      - expired
+      - expiration
+      - must_change
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+          - failure
+        message:
+          type: string
+          enum:
+          - password_expiration
+          - user_not_found
+        expired:
+          type: boolean
+        expiration:
+          anyOf:
+          - type: object
+            required:
+            - timestamp
+            - timezone
+            properties:
+              timestamp:
+                type: integer
+              timezone:
+                type: string
+          - type: 'null'
+        must_change:
+          type: boolean
+    ImportUsersRequest:
+      type: object
+      required:
+      - records
+      properties:
+        skip_existing:
+          type: boolean
+          default: false
+        records:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserImportExportRecord'
+    ImportUsersResponse:
+      type: object
+      required:
+      - status
+      - message
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+          - failure
+        message:
+          type: string
+          enum:
+          - import_success
+          - import_failed
+    ListGroupsResponse:
+      type: object
+      required:
+      - status
+      - message
+      - groups
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+        message:
+          type: string
+          enum:
+          - groups_listed
+        groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupListRecord'
+    ListUsersResponse:
+      type: object
+      required:
+      - status
+      - message
+      - users
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+        message:
+          type: string
+          enum:
+          - users_listed
+        users:
+          type: array
+          items:
+            $ref: '#/components/schemas/ListUserRecord'
+    RemoveGroupRequest:
+      type: object
+      required:
+      - group
+      properties:
+        group:
+          type: string
+          minLength: 1
+    RemoveGroupResponse:
+      type: object
+      required:
+      - status
+      - message
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+        message:
+          type: string
+          enum:
+          - group_removed
+    RemoveUserRequest:
+      type: object
+      required:
+      - user
+      properties:
+        user:
+          type: string
+          minLength: 1
+    RemoveUserResponse:
+      type: object
+      required:
+      - status
+      - message
+      properties:
+        status:
+          type: string
+          enum:
+          - success
+        message:
+          type: string
+          enum:
+          - user_removed

--- a/imageroot/api-moduled/openapi.yaml
+++ b/imageroot/api-moduled/openapi.yaml
@@ -1363,15 +1363,8 @@ components:
           type: boolean
         expiration:
           anyOf:
-          - type: object
-            required:
-            - timestamp
-            - timezone
-            properties:
-              timestamp:
-                type: integer
-              timezone:
-                type: string
+          - type: string
+            format: date-time
           - type: 'null'
         must_change:
           type: boolean

--- a/imageroot/pypkg/samba.py
+++ b/imageroot/pypkg/samba.py
@@ -19,6 +19,8 @@
 #
 
 import ipaddress as ipm
+import datetime
+import re
 import subprocess
 import socket
 import json
@@ -286,6 +288,78 @@ def set_user_account_control(dn_str, user_account_control, no_password_expiratio
         ldbmodify_cmd = ['podman', 'exec', '-i', 'samba-dc', 'ldbmodify', '-H', '/var/lib/samba/private/sam.ldb']
         ldbmodify_input = f'{dn_str}\nchangetype: modify\nreplace: userAccountControl\nuserAccountControl: {user_account_control}\n'
         subprocess.run(ldbmodify_cmd, input=ldbmodify_input, stdout=sys.stderr, check=True, text=True)
+
+def _filetime_to_datetime(filetime):
+    """Convert a Windows FILETIME (100-nanosecond intervals since 1601-01-01 UTC) to a datetime."""
+    if filetime is None or filetime <= 0:
+        return None
+    return datetime.datetime(1601, 1, 1, tzinfo=datetime.timezone.utc) + \
+        datetime.timedelta(microseconds=int(filetime) // 10)
+
+def get_password_settings():
+    result = subprocess.run(
+        ['podman', 'exec', 'samba-dc', 'samba-tool', 'domain', 'passwordsettings', 'show'],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    password_settings = {
+        'expiration': {
+            'max_age': int(re.search(r'Maximum password age \(days\): (\d.*)\n', result.stdout).group(1)),
+            'min_age': int(re.search(r'Minimum password age \(days\): (\d.*)\n', result.stdout).group(1)),
+        },
+        'strength': {
+            'history_length': int(re.search(r'Password history length: (\d.*)\n', result.stdout).group(1)),
+            'password_min_length': int(re.search(r'Minimum password length: (\d.*)\n', result.stdout).group(1)),
+            'complexity_check': re.search(r'Password complexity: (.*)\n', result.stdout).group(1) == 'on',
+        },
+    }
+
+    password_settings['expiration']['enforced'] = password_settings['expiration']['max_age'] > 0 or \
+                                                  password_settings['expiration']['min_age'] > 0
+    password_settings['strength']['enforced'] = password_settings['strength']['history_length'] > 0 or \
+                                                password_settings['strength']['password_min_length'] > 0 or \
+                                                password_settings['strength']['complexity_check']
+
+    if not password_settings['expiration']['enforced']:
+        password_settings['expiration']['max_age'] = 180
+        password_settings['expiration']['min_age'] = 0
+
+    if not password_settings['strength']['enforced']:
+        password_settings['strength']['history_length'] = 24
+        password_settings['strength']['password_min_length'] = 8
+        password_settings['strength']['complexity_check'] = True
+
+    return password_settings
+
+def get_user_password_expiration(user):
+    accounts = _get_accounts()
+    if user not in accounts:
+        raise KeyError(user)
+
+    rec = accounts[user]
+    if rec[ACTYPE] != 'U':
+        raise KeyError(user)
+
+    password_settings = get_password_settings()
+    must_change = rec[ACPWDLASTSET] is None or rec[ACPWDLASTSET] <= 0
+    no_password_expiration = bool(rec[ACUAC] & 0x10000)
+    expiration = None
+    expired = False
+
+    if not must_change and not no_password_expiration and password_settings['expiration']['enforced']:
+        pwd_last_set = _filetime_to_datetime(rec[ACPWDLASTSET])
+        if pwd_last_set is not None:
+            expiry_date = pwd_last_set + datetime.timedelta(days=password_settings['expiration']['max_age'])
+            expired = datetime.datetime.now(datetime.timezone.utc) > expiry_date
+            expiration = expiry_date.isoformat().replace('+00:00', 'Z')
+
+    return {
+        'expired': expired,
+        'expiration': expiration,
+        'must_change': must_change,
+    }
 
 def get_ad_ldap_suffix() -> str:
     """Returns the LDAP base DN suffix derived from the DOMAIN environment variable.

--- a/tests/50__users_admin.robot
+++ b/tests/50__users_admin.robot
@@ -37,6 +37,14 @@ User can login and obtain a token
     Should Not Be Empty    ${token}
     Set Suite Variable    ${TOKEN}    ${token}
 
+User can retrieve own password expiration
+    ${output}  ${error}  ${rc} =  Execute Command    curl -v -H "Authorization: Bearer ${TOKEN}" -H 'Content-type: application/json' --data '{}' -k https://127.0.0.1/users-admin/${DOMAIN}/api/get-password-expiration    return_rc=1  return_stderr=True
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    "status":"success"
+    Should Contain    ${output}    "expiration"
+    Should Contain    ${output}    "expired"
+    Should Contain    ${output}    "must_change":false
+
 Allowed access with valid token
     ${output}  ${error}  ${rc} =  Execute Command    curl -v -H "Authorization: Bearer ${TOKEN}" -H 'Content-type: application/json' --data '{}' -k https://127.0.0.1/users-admin/${DOMAIN}/api/logout    return_rc=1  return_stderr=True
     Should Be Equal As Integers    ${rc}    0


### PR DESCRIPTION
Changes:
- add get-password-expiration API for the user portal
- add openapi.yaml for AI agents

Use the script below for testing, edit:
- user
- password
- port

```
#!/usr/bin/env python3
import json, urllib.request

PORT = 20042

def api(path, token=None, body=None):
    data = json.dumps(body or {}).encode()
    headers = {"Content-Type": "application/json"}
    if token:
        headers["Authorization"] = f"Bearer {token}"
    req = urllib.request.Request(
        f"http://localhost:{PORT}/api/{path}", data=data, headers=headers, method="POST"
    )
    with urllib.request.urlopen(req) as resp:
        return json.loads(resp.read())

# Login
resp = api("login", body={"username": "mario", "password": "Mario,1234"})
token = resp["token"]

# Get password expiration
policy = api("get-password-expiration", token=token)
print(json.dumps(policy, indent=2))
```

Similar PR for OpenLDAP: https://github.com/NethServer/ns8-openldap/pull/137