### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/get-certificate.service
+++ b/imageroot/systemd/user/get-certificate.service
@@ -4,8 +4,8 @@ Description=Get TLS certificate from Traefik
 [Service]
 Type=oneshot
 SuccessExitStatus=0 3
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 SyslogIdentifier=%N
 ExecStart=bash -c '[[ ! -d tls-certs ]] && { mkdir -v tls-certs ; touch tls-certs/ca.pem ; } ; exit 0'
 ExecStart=runagent get-certificate --cert-file=tls-certs/cert.pem --key-file=tls-certs/key.pem $HOSTNAME

--- a/imageroot/systemd/user/samba-dc.service
+++ b/imageroot/systemd/user/samba-dc.service
@@ -7,7 +7,7 @@ After=timescaledb.service get-certificate.service
 Type=forking
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=/etc/nethserver/agent.env
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecCondition=bash -c '[[ -n "$$IPADDRESS" ]]'
@@ -53,7 +53,7 @@ ExecStartPost=/usr/bin/bash -c "[[ $$SERVER_ROLE == member ]] || while ! exec 3<
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%N.cid -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%N.cid
 PIDFile=%t/%N.pid
-WorkingDirectory=%S/state
+WorkingDirectory=%E/state
 
 [Install]
 WantedBy=default.target

--- a/imageroot/systemd/user/timescaledb.service
+++ b/imageroot/systemd/user/timescaledb.service
@@ -3,8 +3,8 @@ Description=TimescaleDB for Samba Audit logs
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%N.pid %t/%N.cid
@@ -18,7 +18,7 @@ ExecStart=/usr/bin/podman run \
     --replace --name %N \
     --env=POSTGRES_DB=samba_audit \
     --env=PGPORT=15432 \
-    --volume=%S/timescaledb-initdb.d:/docker-entrypoint-initdb.d:z \
+    --volume=%E/timescaledb-initdb.d:/docker-entrypoint-initdb.d:z \
     --volume=timescaledb:/var/lib/postgresql/data:z \
     --volume=tsdb_backup:/srv/tsdb_backup:z \
     --env-file=timescaledb.env \


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host